### PR TITLE
Updating to work with new Django 1.6+

### DIFF
--- a/urls_sugar/classes.py
+++ b/urls_sugar/classes.py
@@ -1,7 +1,9 @@
 """ django-urls-sugar classes
 """
-
-from django.conf.urls.defaults import url
+try:
+    from django.conf.urls import url
+except:
+    from django.conf.urls.defaults import url
 
 
 class UrlSugarElement(object):

--- a/urls_sugar/utils.py
+++ b/urls_sugar/utils.py
@@ -21,7 +21,10 @@ def sugar_patterns(original_patterns, prefix, *args):
 def patterns(prefix, *args):
     """ calls sugar_patterns with default django patterns 
     """
-    from django.conf.urls.defaults import patterns as django_patterns
+    try:
+        from django.conf.urls import patterns as django_patterns
+    except:
+        from django.conf.urls.defaults import patterns as django_patterns
     return sugar_patterns(django_patterns, prefix, *args)
 
 


### PR DESCRIPTION
Django eliminated the backwards-compatibility import starting in Django 1.6. Updated import to try new with ability to fallback to old.
https://docs.djangoproject.com/en/1.4/topics/http/urls/#module-django.conf.urls
